### PR TITLE
[BUGFIX] - Fix if statement checking wether shippingData exists of Order

### DIFF
--- a/Observer/Sales/OrderInvoiceSaveAfter.php
+++ b/Observer/Sales/OrderInvoiceSaveAfter.php
@@ -133,7 +133,7 @@ class OrderInvoiceSaveAfter implements \Magento\Framework\Event\ObserverInterfac
             $substituteShippingAddress = $this->addressFactory->create();
         }
 
-        if ($order->getShippigAddress()) {
+        if ($order->getShippingAddress()) {
             $shippingAddressData = $order->getShippingAddress()->getData();
         } else {
             $shippingAddressData = $order->getBillingAddress()->getData();

--- a/Observer/Sales/OrderSaveAfter.php
+++ b/Observer/Sales/OrderSaveAfter.php
@@ -128,7 +128,7 @@ class OrderSaveAfter implements \Magento\Framework\Event\ObserverInterface
             $substituteShippingAddress = $this->addressFactory->create();
         }
 
-        if ($order->getShippigAddress()) {
+        if ($order->getShippingAddress()) {
             $shippingAddressData = $order->getShippingAddress()->getData();
         } else {
             $shippingAddressData = $order->getBillingAddress()->getData();


### PR DESCRIPTION
Hi, while assisting a colleague debugging an issue where address data wasn't properly saved when the shipping & billing data was different. I found that the getShippingData if statement had a spelling error in this regard. Although these changes solved that issue, my colleague is now investigating a new issue in regards the observer creating more then 2 records. I've informed him to give you an update when he found the cause.