### PR TITLE
Fix integration tests by adding proxies

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -77,4 +77,13 @@
             </argument>
         </arguments>
     </type>
+	
+    <!-- Fix failing integration test by lazy loading dependencies -->
+    <type name="Dealer4Dealer\SubstituteOrders\Console\Command\UpdateOrders">
+        <arguments>
+            <argument name="orderSaveAfter" xsi:type="object">Dealer4Dealer\SubstituteOrders\Observer\Sales\OrderSaveAfter\Proxy</argument>
+            <argument name="orderInvoiceSaveAfter" xsi:type="object">\Dealer4Dealer\SubstituteOrders\Observer\Sales\OrderInvoiceSaveAfter\Proxy</argument>
+            <argument name="shipmentSaveAfter" xsi:type="object">Dealer4Dealer\SubstituteOrders\Observer\Sales\OrderShipmentSaveAfter\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Magento 2 integration tests fail when this module is installed. Adding proxies solves this.