### PR TITLE
[BUGFIX] - Declare parameter types to fix fatal error when using addi…

### DIFF
--- a/Model/AdditionalData.php
+++ b/Model/AdditionalData.php
@@ -28,6 +28,10 @@ class AdditionalData implements AdditionalDataInterface
     protected $key;
     protected $value;
 
+    /**
+     * @param string $key
+     * @param string $value
+     */
     public function __construct($key = '', $value = '')
     {
         $this->key = $key;


### PR DESCRIPTION
…tional data in call

Error:
Fatal error: Uncaught TypeError: Argument 2 passed to Magento\Framework\Reflection\TypeProcessor::resolveFullyQualifiedClassName() must be of the type string, null given