### PR TITLE
[BUGFIX] - Optional parameters should be last in PHP 8.x

### DIFF
--- a/Block/Order/Item/Renderer/DefaultRenderer.php
+++ b/Block/Order/Item/Renderer/DefaultRenderer.php
@@ -44,8 +44,8 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Framework\Stdlib\StringUtils $string,
         \Magento\Catalog\Model\Product\OptionFactory $productOptionFactory,
+        \Magento\Framework\Registry $registry,
         array $data = [],
-        \Magento\Framework\Registry $registry
     ) {
         $this->string = $string;
         $this->_productOptionFactory = $productOptionFactory;

--- a/Controller/Attachment/Download.php
+++ b/Controller/Attachment/Download.php
@@ -108,8 +108,8 @@ class Download extends \Magento\Framework\App\Action\Action
             $fileNameParts = explode('/', $attachment->getFile());
             $fileName = end($fileNameParts);
             $filePath = $attachment->getBasePath(
-                $attachment->getMagentoCustomerIdentifier(),
-                $attachment->getEntityType()
+                $attachment->getEntityType(),
+                $attachment->getMagentoCustomerIdentifier()
             );
             $filePath .= $attachment->getFile();
 

--- a/Model/Attachment.php
+++ b/Model/Attachment.php
@@ -152,7 +152,7 @@ class Attachment extends \Magento\Framework\Model\AbstractModel implements Attac
      *
      * @return string
      */
-    public function getBasePath($customerIdentifier = '0', $entityType)
+    public function getBasePath($entityType,$customerIdentifier = '0')
     {
         return 'customer/substitute_order/files/' . $customerIdentifier . '/' . $entityType;
     }

--- a/Model/File/ContentUploader.php
+++ b/Model/File/ContentUploader.php
@@ -133,7 +133,7 @@ class ContentUploader extends Uploader implements \Dealer4Dealer\SubstituteOrder
      */
     public function getDestinationDirectory($customerIdentifier, $entityType)
     {
-        $directory = $this->mediaDirectory->getAbsolutePath($this->attachmentConfig->getBasePath($customerIdentifier, $entityType));
+        $directory = $this->mediaDirectory->getAbsolutePath($this->attachmentConfig->getBasePath($entityType, $customerIdentifier));
         return $directory;
     }
 }


### PR DESCRIPTION
Deprecated Functionality: Optional parameter declared before required parameter is implicitly treated as a required parameter