### PR TITLE
Fix empty page while downloading a PDF

### DIFF
--- a/Controller/Attachment/Download.php
+++ b/Controller/Attachment/Download.php
@@ -113,7 +113,7 @@ class Download extends \Magento\Framework\App\Action\Action
             );
             $filePath .= $attachment->getFile();
 
-            $this->fileFactory->create(
+            return $this->fileFactory->create(
                 $fileName,
                 [
                     'type' => 'filename',


### PR DESCRIPTION
I'm currently having issues downloading the order PDF's. This is probably not the fix that you would like, but this does seem to fix my problem. I'm getting an empty page while downloading the PDF. The file does exist.