### PR TITLE
Make console command compatible with Symfony 7.x

### DIFF
--- a/Console/Command/UpdateOrders.php
+++ b/Console/Command/UpdateOrders.php
@@ -54,7 +54,7 @@ class UpdateOrders extends Command
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
+    ): int {
         $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
 
         $collection = $this->orderFactory->create()->getCollection();
@@ -109,6 +109,8 @@ class UpdateOrders extends Command
 
             $page++;
         }
+
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 
     /**


### PR DESCRIPTION
Add typehint return value to adhere to Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int signature